### PR TITLE
update form to receive every hazard type

### DIFF
--- a/frontend/app-dashboard/css/side-panel.css
+++ b/frontend/app-dashboard/css/side-panel.css
@@ -429,3 +429,42 @@ form label {
 .panel-chart, .panel-chart-road, .panel-chart-primary {
     margin-top: 15px
 }
+
+form input[type=file] {
+    height: 37px !important;
+}
+
+form label {
+    font-weight: 600;
+    margin-top: 5px;
+}
+
+.hazard-input {
+    border: 1px solid #ccc;
+    padding: 10px 20px;
+    margin-bottom: 10px;
+}
+
+.hazard-input select {
+    cursor: pointer;
+}
+
+.hazard-input-guide {
+    font-size: 12px;
+}
+
+.hazard-input-guide .fa {
+    color: green;
+    cursor: pointer;
+    margin-left: 5px;
+}
+
+.hazard-input-guide table {
+    margin-top: 10px;
+}
+
+.hazard-input-guide td, .hazard-input-guide th {
+    text-align: left;
+    border: 1px solid #ddd;
+    padding: 3px;
+}

--- a/frontend/app-dashboard/dashboard.html
+++ b/frontend/app-dashboard/dashboard.html
@@ -47,10 +47,10 @@
 					forecast dashboard to trigger Early Action.</p>
 
 					<p>To get started, use the green flood selector icon below to
-					select a historical or forecast flood event (valid 
+					select a historical or forecast flood event (valid
 					dates have circles around them).</p>
-				    
-					<p>This site is developed in collaboration with the 
+
+					<p>This site is developed in collaboration with the
 					<a href="https://www.climatecentre.org">Red
 					Cross Red Crescent Climate Centre</a> with funding from the
 					World Bank GFDRR Challenge Fund and contributing to the
@@ -96,7 +96,7 @@
             <div class="panel-body-wrapper panel-body panel-flood-scenario" style="display: none">
                 <button class="btn btn-back pull-left"><i class="fa fa-chevron-circle-left" aria-hidden="true"></i></button>
                 <div class="panel-title">
-                    Add Flood Forecast 
+                    Add Flood Forecast
                 </div>
                 <div class="panel-body">
                     <button class="btn btn-warning btn-primary-1 btn-full-width" id="draw-flood" style="display: none;">Draw Flood Forecast</button>
@@ -115,6 +115,9 @@
                     <div id="draw-flood-form">
                         <form role="form" id="draw-form" enctype="multipart/form-data" class="form-horizontal">
                             <div class="form-group">
+                                <label for="draw_hazard_type">Hazard type</label>
+                                <select class="form-control" name="hazard_type" id="draw_hazard_type" required></select>
+
                                 <label for="draw_place_name">Place name</label>
                                 <input class="form-control" name="place_name" id="draw_place_name" type="text">
                                 <label for="draw_event_notes">Event notes</label>
@@ -138,11 +141,11 @@
                                 <div class="row">
                                     <div class="col-lg-6" style="padding-right: 5px">
                                         <label for="draw_acquisition_date">Acquisition date </label>
-                                        <input class="form-control datepicker-here" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="acquisition_date" id="draw_acquisition_date" style="font-size: 10px;">
+                                        <input class="form-control datepicker-here" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="acquisition_date" id="draw_acquisition_date" style="font-size: 10px;" autocomplete="off">
                                     </div>
                                     <div class="col-lg-6" style="padding-left: 5px">
                                         <label for="draw_forecast_date">Forecast date </label>
-                                        <input class="form-control datepicker-here" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="forecast_date" id="draw_forecast_date" style="font-size: 10px;">
+                                        <input class="form-control datepicker-here" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="forecast_date" id="draw_forecast_date" style="font-size: 10px;" autocomplete="off">
                                     </div>
                                 </div>
                                 <button type="submit" value="submit" class="btn btn-warning btn-primary-1 pull-right">Save</button>
@@ -158,6 +161,15 @@
                     <div id="upload-flood-form-wrapper">
                         <form role="form" method="post" id="upload-flood-form" enctype="multipart/form-data" class="form-horizontal" action="javascript:void(0)">
                             <div class="form-group">
+                                <div class="hazard-input">
+                                    <label for="hazard_type">Hazard type</label>
+                                    <select class="form-control" name="hazard_type" id="hazard_type" required></select>
+                                    <div class="hazard-input-guide">
+                                        Geojson need <b>class</b> on property, which the value are : <i class="fa fa-caret-square-o-down" aria-hidden="true"></i>
+                                        <div class="hazard-input-guide-content" style="display: none">
+                                        </div>
+                                    </div>
+                                </div>
                                 <label for="upload_place_name">Place name</label>
                                 <input class="form-control" name="place_name" id="upload_place_name" type="text">
                                 <label for="upload_source">Source</label>
@@ -182,11 +194,11 @@
                                 <div class="row">
                                     <div class="col-lg-6" style="padding-right: 5px">
                                         <label for="upload_acquisition_date">Acquisition date </label>
-                                        <input class="form-control datepicker-here" data-date-format="yyyy-mm-dd" data-time-format="hh:ii" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="acquisition_date" id="upload_acquisition_date" style="font-size: 10px;">
+                                        <input class="form-control datepicker-here" data-date-format="yyyy-mm-dd" data-time-format="hh:ii" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="acquisition_date" id="upload_acquisition_date" style="font-size: 10px;" autocomplete="off">
                                     </div>
                                     <div class="col-lg-6" style="padding-left: 5px">
                                         <label for="upload_forecast_date">Forecast date </label>
-                                        <input class="form-control datepicker-here" data-date-format="yyyy-mm-dd" data-time-format="hh:ii" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="forecast_date" id="upload_forecast_date" style="font-size: 10px;">
+                                        <input class="form-control datepicker-here" data-date-format="yyyy-mm-dd" data-time-format="hh:ii" data-language="en" data-timepicker="true" data-position="left bottom" type="text" name="forecast_date" id="upload_forecast_date" style="font-size: 10px;" autocomplete="off">
                                     </div>
                                 </div>
                                 <br/>

--- a/frontend/app-dashboard/js/model/depth_class.js
+++ b/frontend/app-dashboard/js/model/depth_class.js
@@ -18,7 +18,7 @@ define([
 
     return Backbone.Collection.extend({
         model: DepthClass,
-        urlRoot: postgresUrl + 'hazard_class',
+        urlRoot: postgresUrl + 'hazard_class?order=id',
         url: function () {
             return this.urlRoot
         }

--- a/frontend/app-dashboard/js/model/flood.js
+++ b/frontend/app-dashboard/js/model/flood.js
@@ -45,7 +45,7 @@ define([
             _geojson_attrs: {
                 flood_class_field: "class"
             },
-        
+
             initialize: function (){
                 this._uploaded_features = 0;
                 this.on('feature-uploaded', this.featureUploaded, this);
@@ -66,7 +66,7 @@ define([
                 }
                 return 0;
             },
-        
+
             featureUploaded: function(feature){
                 if(feature) {
                     this._uploaded_features++;
@@ -256,7 +256,7 @@ define([
                 }
                 return false;
             },
-        
+
             _validateDepthClassAttribute: function () {
                 const geojson = this.get('geojson');
                 const areas = geojson.features;
@@ -283,7 +283,10 @@ define([
 
                     function _process_geojson(geojson){
                         try {
-                            const layer = FloodLayer.fromGeoJSON(JSON.parse(geojson));
+                            const layer = FloodLayer.fromGeoJSON(
+                                JSON.parse(geojson),
+                                {classes :flood_map_attributes.hazard_classes}
+                            );
                             layer.set({
                                 place_name: place_name,
                                 return_period: return_period,
@@ -360,8 +363,19 @@ define([
                 const validated_geojson = layer.get('geojson');
 
                 const areas = validated_geojson.features.map(function(value){
+                    // check the class based on the
+                    let hazardClass = value.properties[layer._geojson_attrs.flood_class_field]
+                    if (attributes && attributes['classes']) {
+                        if (!attributes['classes'].includes(hazardClass)){
+                            let e = {
+                                'layer': layer,
+                                'message': `Class "${hazardClass}" is not valid for selected hazard`
+                            }
+                            throw e
+                        }
+                    }
                     return {
-                        depth_class: value.properties[layer._geojson_attrs.flood_class_field],
+                        depth_class: hazardClass,
                         geometry: value.geometry
                     }
                 })

--- a/frontend/app-dashboard/js/model/hazard_type.js
+++ b/frontend/app-dashboard/js/model/hazard_type.js
@@ -1,0 +1,25 @@
+/**
+ * Hazard type model
+ * - id
+ * - name
+ */
+define([
+    'backbone',
+    'moment'
+], function (Backbone) {
+
+    const HazardType = Backbone.Model.extend({
+        urlRoot: postgresUrl + 'hazard_type',
+        url: function () {
+            return `${this.urlRoot}?id=eq.${this.id}`
+        }
+    });
+
+    return Backbone.Collection.extend({
+        model: HazardType,
+        urlRoot: postgresUrl + 'hazard_type?order=name',
+        url: function () {
+            return this.urlRoot;
+        }
+    });
+});

--- a/frontend/app-dashboard/js/view/flood-collection.js
+++ b/frontend/app-dashboard/js/view/flood-collection.js
@@ -500,7 +500,7 @@ define([
                 overall['region'] = region;
             }
             dispatcher.trigger('dashboard:render-chart-building', overall, 'building');
-            dispatcher.trigger('dashboard:render-region-summary', overall, buildings, main_panel, region_render, that.keyStats[region_render], 'building');
+            dispatcher.trigger('dashboard:render-region-summary', overall, buildings, main_panel, region_render, that.keyStats[region_render], 'building', this.selected_forecast.get('hazard_type'));
         },
         fetchVillageData: function (flood_event_id) {
             let that = this;
@@ -661,7 +661,7 @@ define([
                 overall['region'] = region;
             }
             dispatcher.trigger('dashboard:render-chart-road', overall, 'road');
-            dispatcher.trigger('dashboard:render-region-summary', overall, roads, main_panel, region_render, that.keyStats[region_render], 'road');
+            dispatcher.trigger('dashboard:render-region-summary', overall, roads, main_panel, region_render, that.keyStats[region_render], 'road', this.selected_forecast.get('hazard_type'));
         },
         fetchRoadDistrictData: function (flood_event_id) {
             let that = this;
@@ -787,7 +787,7 @@ define([
                 overall['region'] = region;
             }
             dispatcher.trigger('dashboard:render-chart-population', overall, 'population');
-            dispatcher.trigger('dashboard:render-region-summary', overall, population, main_panel, region_render, that.keyStats[region_render], 'population');
+            dispatcher.trigger('dashboard:render-region-summary', overall, population, main_panel, region_render, that.keyStats[region_render], 'population', this.selected_forecast.get('hazard_type'));
         },
         _merge_population_stats: function(flood_event_id, stats_data, stats_collections, region){
             let that = this;

--- a/frontend/app-dashboard/js/view/forms/hazard-type-input.js
+++ b/frontend/app-dashboard/js/view/forms/hazard-type-input.js
@@ -1,0 +1,88 @@
+/**
+ * View for handling hazard type input on a form
+ */
+define([
+    'backbone',
+    'js/model/hazard_type.js',
+    'js/model/depth_class.js',], function (Backbone, HazardTypeCollection, HazardClassCollection) {
+    return Backbone.View.extend({
+        classesByType: {},
+        initialize: function ($form) {
+            this.classesByType = {}
+            this.$input = $form.find('select[name$="hazard_type"]')
+            this.$classGuide = $form.find('.hazard-input-guide')
+            this.$guideToggler = this.$classGuide.find('.fa')
+            this.$classGuideContent = $form.find('.hazard-input-guide-content')
+
+            this.initData()
+            this.initEventListener()
+        },
+        /** Initiate data for hazard selection
+         */
+        initData: function () {
+            // get hazard type list
+            const that = this
+            let typeCollection = new HazardTypeCollection()
+            typeCollection.fetch().then(function (data) {
+                data.forEach(function (value) {
+                    that.$input.append(`<option value="${value.id}">${value.name}</option>`)
+                });
+            }).catch(function (data) {
+                console.log('Hazard type request failed');
+                console.log(data);
+            });
+
+            // get hazard class list
+            let classCollection = new HazardClassCollection()
+            classCollection.fetch().then(function (data) {
+                data.map(x => {
+                    if (!x.hazard_type) {
+                        x.hazard_type = 1
+                    }
+                    if (!that.classesByType[x.hazard_type]) {
+                        that.classesByType[x.hazard_type] = []
+                    }
+                    that.classesByType[x.hazard_type].push(x.id)
+
+                    // append the data
+                    if (that.$classGuideContent.find(`#hazard-type-${x.hazard_type}`).length === 0) {
+                        that.$classGuideContent.append('' +
+                            `<table style="width:100%; display: none" id="hazard-type-${x.hazard_type}">` +
+                            '   <tr><th>class</th><th>description</th></tr>' +
+                            ' </table>')
+                    }
+                    that.$classGuideContent.find(`#hazard-type-${x.hazard_type}`).append(
+                        `<tr><td>${x.id}</td><th>${x.label}</th></tr>`
+                    )
+                });
+                that.$classGuideContent.find(`#hazard-type-${that.$input.val()}`).show()
+            }).catch(function (data) {
+                console.log('Hazard type request failed');
+                console.log(data);
+            });
+        },
+        /** Initiate event listener
+         */
+        initEventListener: function () {
+            // event listener for guide toggler
+            const that = this;
+            this.$guideToggler.click(function () {
+                that.$classGuideContent.slideToggle()
+                if ($(this).hasClass("fa-caret-square-o-down")) {
+                    $(this).addClass("fa-caret-square-o-up").removeClass("fa-caret-square-o-down")
+                } else {
+                    $(this).addClass("fa-caret-square-o-down").removeClass("fa-caret-square-o-up")
+                }
+            })
+            this.$input.change(function () {
+                that.$classGuideContent.find('table').hide()
+                that.$classGuideContent.find(`#hazard-type-${$(this).val()}`).show()
+            })
+        },
+        /** Get current classes
+         */
+        returnCurrentClasses: function () {
+            return this.classesByType[this.$input.val()]
+        },
+    });
+});

--- a/frontend/app-dashboard/js/view/layers/flood-form.js
+++ b/frontend/app-dashboard/js/view/layers/flood-form.js
@@ -18,6 +18,7 @@ define([
             this.$depth_class = $form.find("input[name='depth_class']");
             this.$acquisition_date = $form.find("input[name='acquisition_date']");
             this.$forecast_date = $form.find("input[name='forecast_date']");
+            this.$hazard_type = $form.find("select[name='hazard_type']");
         },
         create_data: function (polygon) {
             const that = this;
@@ -33,6 +34,7 @@ define([
             const depth_class = this.$depth_class.val();
             const acquisition_date = new Date(this.$acquisition_date.val()).toMysqlFormat();
             const forecast_date = new Date(this.$forecast_date.val()).toMysqlFormat();
+            const hazard_type = this.$hazard_type.val();
 
             // assign depth class to geojson
             const feature = Wellknown.parse(polygon);
@@ -53,7 +55,8 @@ define([
                 link: source_url,
                 notes: event_notes,
                 acquisition_date: acquisition_date,
-                forecast_date: forecast_date
+                forecast_date: forecast_date,
+                hazard_type_id: hazard_type
             };
 
             const forecast_event = new ForecastEvent(forecast_event_attr);

--- a/frontend/app-dashboard/js/view/layers/upload-flood.js
+++ b/frontend/app-dashboard/js/view/layers/upload-flood.js
@@ -4,8 +4,9 @@ define([
     'jquery',
     'moment',
     'js/model/flood.js',
-    'js/model/forecast_event.js'
-], function (Backbone, _, $, moment, FloodModel, ForecastEvent) {
+    'js/model/forecast_event.js',
+    'js/view/forms/hazard-type-input.js'
+], function (Backbone, _, $, moment, FloodModel, ForecastEvent, HazardTypeInput) {
     return Backbone.View.extend({
         el: "#upload-flood-form",
         events: {
@@ -25,6 +26,8 @@ define([
             this.$return_period = $form.find("select[name='return_period']");
             this.$acquisition_date = $form.find("input[name='acquisition_date']");
             this.$forecast_date = $form.find("input[name='forecast_date']");
+            this.$hazard_type = $form.find("select[name='hazard_type']");
+            this.hazardInput = new HazardTypeInput($('#upload-flood-form'));
         },
 
         submitForm: function(e){
@@ -43,14 +46,15 @@ define([
             const return_period = this.$return_period.val();
             const acquisition_date = moment.fromAirDateTimePicker(this.$acquisition_date.val()).format();
             const forecast_date = moment.fromAirDateTimePicker(this.$forecast_date.val()).format();
-
+            const hazard_type = this.$hazard_type.val();
 
             const forecast_event_attr = {
                 source: source,
                 link: source_url,
                 notes: event_notes,
                 acquisition_date: acquisition_date,
-                forecast_date: forecast_date
+                forecast_date: forecast_date,
+                hazard_type_id: hazard_type
             };
 
             const forecast_event = new ForecastEvent(forecast_event_attr);
@@ -60,7 +64,9 @@ define([
                 files: geojson,
                 place_name: place_name,
                 return_period: return_period,
-                flood_model_notes: flood_model_notes})
+                flood_model_notes: flood_model_notes,
+                hazard_classes: that.hazardInput.returnCurrentClasses()
+            })
                 .then(function(flood){
                     that.flood = flood;
 

--- a/frontend/app-dashboard/js/view/panel-dashboard.js
+++ b/frontend/app-dashboard/js/view/panel-dashboard.js
@@ -96,7 +96,7 @@ define([
                 callback();
             }
         },
-        renderRegionSummary: function (overall, data, main_panel, sub_region, id_field, exposure_name) {
+        renderRegionSummary: function (overall, data, main_panel, sub_region, id_field, exposure_name, hazard_type) {
             // main panel title (the region)
             let that = this;
             let id_key = {
@@ -116,7 +116,12 @@ define([
                 if (!that.containsReferer(referer, that.referer_region)) {
                     that.referer_region.push(referer);
                 }
-                $('#main-panel-header').html('Summary for Flood ' + floodCollectionView.selected_forecast.attributes.notes)
+                if (!hazard_type) {
+                   hazard_type = 'hazard'
+                } else {
+                    hazard_type = hazard_type['name']
+                }
+                $('#main-panel-header').html(`Summary for <b>${hazard_type}</b> ${floodCollectionView.selected_forecast.attributes.notes}`)
             } else {
                 $('.btn-back-summary-panel').show();
                 let referer = {


### PR DESCRIPTION
this fix https://trello.com/c/Z3DAJgjc/185-fba-hazard-uploader

Update form to receive hazard type

Hazard type list is from database (not hardcoded)
![Selection_059](https://user-images.githubusercontent.com/4530905/81795195-10273900-9536-11ea-9318-d98f292cc4aa.png)

In summary, all **Flooded** change to **Affected**
Also title will change into hazard type
![Selection_060](https://user-images.githubusercontent.com/4530905/81795239-1a493780-9536-11ea-991d-fac6f0263bd6.png)

TODO:
- when change hazard type, show user that what data should be done on their geojson (mostly for class value), maybe show the correct legend for the hazard type and the correct class id
- validate the class input on geojson for selected hazard type