### PR TITLE
fix fba calls layer when layers parameter is empty

### DIFF
--- a/frontend/app-dashboard/js/view/layers/templates/wms-layer.js
+++ b/frontend/app-dashboard/js/view/layers/templates/wms-layer.js
@@ -32,30 +32,36 @@ define([
                 transparent: true,
                 tiled: true,
             };
+            if (!this.layer) {
+                // add the layer
+                this.layer = L.tileLayer.wms(
+                    this._url, parameters);
+                this.group = L.layerGroup([this.layer]);
+                this.map.addLayer(this.group);
+                this._id = this.layer._leaflet_id;
+            } else {
+                this.layer.setParams(parameters);
+            }
 
+            // for bbox layer
             let parameters_bbox = {
                 layers: this._bbox_layer,
                 format: 'image/png',
                 transparent: true,
                 tiled: true,
             };
-
             if (cqlFilters) {
                 parameters_bbox['cql_filter'] = cqlFilters
             }
-            if (!this.layer) {
-                // add the layer
-                this.bbox_layer = L.tileLayer.wms(
-                    this._url, parameters_bbox);
-
-                this.layer = L.tileLayer.wms(
-                    this._url, parameters);
-                this.group = L.layerGroup([this.layer, this.bbox_layer]);
-                this.map.addLayer(this.group);
-                this._id = this.layer._leaflet_id;
+            if (!this.bbox_layer) {
+                if(parameters_bbox.layers) {
+                    // add the layer
+                    this.bbox_layer = L.tileLayer.wms(
+                        this._url, parameters_bbox);
+                    this.group.addLayer(this.bbox_layer)
+                }
             } else {
                 delete (this.bbox_layer.wmsParams.cql_filter);
-                this.layer.setParams(parameters);
                 this.bbox_layer.setParams(parameters_bbox)
             }
         },


### PR DESCRIPTION
Fixing fba call layer to geoserver when layers parameter is empty (we can look on the console on the load)

PR to the upstream : inasafe#87