### PR TITLE
Add more configuration to django backend

### DIFF
--- a/mapserver/django/django_project/core/settings/prod_docker.py
+++ b/mapserver/django/django_project/core/settings/prod_docker.py
@@ -13,3 +13,5 @@ DATABASES = {
         'NAME': os.path.join(ABS_PATH('./'), 'db.sqlite3'),
     }
 }
+
+FIXTURES = '/home/web/fixtures'

--- a/mapserver/django/django_project/core/settings/project.py
+++ b/mapserver/django/django_project/core/settings/project.py
@@ -12,6 +12,9 @@ from .contrib import *  # noqa
 
 # Due to profile page does not available,
 # this will redirect to home page after login
+from .utils import ABS_PATH
+import ast
+
 LOGIN_REDIRECT_URL = '/'
 
 # How many versions to list in each project box
@@ -37,4 +40,6 @@ INSTALLED_APPS += (
 MAPSERVER_PUBLIC_WMS_URL = os.environ.get('MAPSERVER_PUBLIC_WMS_URL', None)
 MAPSERVER_PUBLIC_OWS_URL = os.environ.get('MAPSERVER_PUBLIC_OWS_URL', None)
 MAPSERVER_PUBLIC_SLD_URL = os.environ.get('MAPSERVER_PUBLIC_SLD_URL', None)
-FIXTURES = '/home/web/fixtures'
+FIXTURES = ABS_PATH('../../fixtures')
+# Specify settings to ignore Python Requests SSL verification
+REQUESTS_SSL_VERIFY = ast.literal_eval(os.environ.get('REQUESTS_SSL_VERIFY', 'False'))

--- a/mapserver/django/django_project/core/wsgi.py
+++ b/mapserver/django/django_project/core/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings.prod")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings.prod_docker")
 
 application = get_wsgi_application()


### PR DESCRIPTION
- Allow Python Requests module to fetch unsecure
  https (used for internal mapserver proxying)
- Allow path name resolve of the fixture data
  for layer styles